### PR TITLE
feat: add initial ReputeAI Vue front-end

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ReputeAI</title>
+  </head>
+  <body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "reputeai-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "@headlessui/vue": "^1.7.15",
+    "@heroicons/vue": "^2.1.1",
+    "axios": "^1.7.2",
+    "chart.js": "^4.4.0",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.0",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <Navbar />
+    <router-view />
+  </div>
+</template>
+
+<script setup>
+import Navbar from './components/Navbar.vue';
+</script>

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: '/api'
+});
+
+// Placeholder for fetching reviews
+export async function fetchReviews() {
+  // return api.get('/reviews');
+  return [];
+}

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="h-64">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import { Chart, PieController, ArcElement, Tooltip, Legend, BarController, BarElement, CategoryScale, LinearScale } from 'chart.js';
+
+Chart.register(PieController, ArcElement, Tooltip, Legend, BarController, BarElement, CategoryScale, LinearScale);
+
+const props = defineProps({
+  type: { type: String, default: 'pie' },
+  data: { type: Object, required: true }
+});
+
+const canvas = ref(null);
+
+onMounted(() => {
+  new Chart(canvas.value, {
+    type: props.type,
+    data: props.data,
+    options: { responsive: true, maintainAspectRatio: false }
+  });
+});
+</script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,0 +1,34 @@
+<template>
+  <nav class="bg-white dark:bg-gray-800 shadow">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between h-16">
+        <div class="flex">
+          <router-link to="/" class="flex-shrink-0 flex items-center text-primary font-bold text-xl">ReputeAI</router-link>
+        </div>
+        <div class="flex items-center space-x-4">
+          <button @click="toggleDark" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
+            <MoonIcon v-if="!isDark" class="h-5 w-5" />
+            <SunIcon v-else class="h-5 w-5" />
+          </button>
+          <router-link to="/login" class="text-sm font-medium text-gray-700 dark:text-gray-300">Login</router-link>
+        </div>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline';
+
+const isDark = ref(false);
+
+onMounted(() => {
+  isDark.value = document.documentElement.classList.contains('dark');
+});
+
+function toggleDark() {
+  isDark.value = !isDark.value;
+  document.documentElement.classList.toggle('dark', isDark.value);
+}
+</script>

--- a/src/components/ReviewCard.vue
+++ b/src/components/ReviewCard.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="p-4 bg-white dark:bg-gray-800 rounded shadow mb-4">
+    <div class="flex justify-between items-start">
+      <div>
+        <p class="font-semibold">{{ review.reviewer }}</p>
+        <p class="text-sm text-gray-500">{{ review.platform }}</p>
+      </div>
+      <span :class="sentimentClass">{{ review.sentiment }}</span>
+    </div>
+    <p class="mt-2 text-gray-700 dark:text-gray-300">{{ review.text }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  review: Object
+});
+
+const sentimentClass = computed(() => {
+  switch (props.review.sentiment) {
+    case 'Positive':
+      return 'text-green-600';
+    case 'Negative':
+      return 'text-red-600';
+    default:
+      return 'text-yellow-600';
+  }
+});
+</script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 w-64 min-h-screen shadow-md hidden md:block">
+    <nav class="mt-5">
+      <router-link v-for="item in items" :key="item.to" :to="item.to" class="block px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+        {{ item.label }}
+      </router-link>
+    </nav>
+  </div>
+</template>
+
+<script setup>
+const items = [
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/reviews', label: 'Reviews' },
+  { to: '/settings', label: 'Settings' },
+  { to: '/billing', label: 'Billing' }
+];
+</script>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,10 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import router from './router';
+import './index.css';
+
+const app = createApp(App);
+app.use(createPinia());
+app.use(router);
+app.mount('#app');

--- a/src/pages/Billing.vue
+++ b/src/pages/Billing.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6">
+      <h1 class="text-2xl font-bold mb-4">Billing</h1>
+      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow">
+        <p class="mb-2">Current Plan: <strong>Free</strong></p>
+        <button class="px-4 py-2 bg-primary text-white rounded">Upgrade to Pro</button>
+        <p class="mt-4 text-sm text-gray-500">Stripe checkout coming soon.</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '../components/Sidebar.vue';
+</script>

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6">
+      <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+      <div class="grid md:grid-cols-2 gap-6 mb-6">
+        <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+          <h2 class="text-lg font-semibold mb-2">Total Reviews</h2>
+          <p class="text-3xl">{{ totalReviews }}</p>
+        </div>
+        <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+          <h2 class="text-lg font-semibold mb-2">Sentiment</h2>
+          <Chart :type="'pie'" :data="chartData" />
+        </div>
+      </div>
+      <h2 class="text-lg font-semibold mb-2">Recent Reviews</h2>
+      <ReviewCard v-for="r in reviews.slice(0,3)" :key="r.id" :review="r" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '../components/Sidebar.vue';
+import Chart from '../components/Chart.vue';
+import ReviewCard from '../components/ReviewCard.vue';
+import { useReviewsStore } from '../stores/reviews';
+import { computed } from 'vue';
+
+const reviewStore = useReviewsStore();
+const reviews = reviewStore.reviews;
+
+const totalReviews = computed(() => reviews.length);
+
+const chartData = {
+  labels: ['Positive', 'Neutral', 'Negative'],
+  datasets: [
+    {
+      data: [
+        reviews.filter(r => r.sentiment === 'Positive').length,
+        reviews.filter(r => r.sentiment === 'Neutral').length,
+        reviews.filter(r => r.sentiment === 'Negative').length
+      ],
+      backgroundColor: ['#22c55e', '#eab308', '#ef4444']
+    }
+  ]
+};
+</script>

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <section class="text-center py-20 bg-gray-50">
+      <h1 class="text-4xl font-bold text-gray-900 mb-4">Manage Your Online Reputation with AI</h1>
+      <p class="text-lg text-gray-600 mb-6">Monitor reviews, analyze sentiment, and respond in seconds.</p>
+      <div class="space-x-4">
+        <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded shadow">Start Free Trial</router-link>
+        <router-link to="/demo" class="px-4 py-2 border border-primary text-primary rounded">View Demo</router-link>
+      </div>
+    </section>
+
+    <section class="py-16">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8">
+        <div class="bg-white p-6 rounded shadow">
+          <h3 class="font-semibold mb-2">Track Google & Trustpilot Reviews</h3>
+          <p class="text-gray-600">Stay updated with new feedback across platforms.</p>
+        </div>
+        <div class="bg-white p-6 rounded shadow">
+          <h3 class="font-semibold mb-2">AI Sentiment Analysis</h3>
+          <p class="text-gray-600">Understand customer feelings instantly.</p>
+        </div>
+        <div class="bg-white p-6 rounded shadow">
+          <h3 class="font-semibold mb-2">Suggested Responses with Your Brand Voice</h3>
+          <p class="text-gray-600">Reply confidently with AI-generated messages.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-16 bg-gray-50">
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-3xl font-bold mb-8">Pricing</h2>
+        <div class="grid md:grid-cols-2 gap-8">
+          <div class="bg-white p-6 rounded shadow">
+            <h3 class="text-xl font-semibold mb-4">Free Plan</h3>
+            <p class="text-gray-600 mb-4">10 reviews/month</p>
+            <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded">Get Started</router-link>
+          </div>
+          <div class="bg-white p-6 rounded shadow">
+            <h3 class="text-xl font-semibold mb-4">Pro Plan</h3>
+            <p class="text-gray-600 mb-4">Unlimited reviews + AI responses<br/>€29/month</p>
+            <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded">Upgrade</router-link>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer class="py-8 text-center text-gray-500">
+      <div class="space-x-4">
+        <a href="#">About</a>
+        <a href="#">Pricing</a>
+        <a href="#">Contact</a>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="max-w-md mx-auto py-20">
+    <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
+    <form class="space-y-4">
+      <input type="email" placeholder="Email" class="w-full p-2 border rounded" />
+      <input type="password" placeholder="Password" class="w-full p-2 border rounded" />
+      <button class="w-full bg-primary text-white py-2 rounded">Login</button>
+    </form>
+  </div>
+</template>

--- a/src/pages/Reviews.vue
+++ b/src/pages/Reviews.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6">
+      <h1 class="text-2xl font-bold mb-4">Reviews</h1>
+      <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+        <thead>
+          <tr class="text-left">
+            <th class="p-2">Platform</th>
+            <th class="p-2">Reviewer</th>
+            <th class="p-2">Rating</th>
+            <th class="p-2">Review</th>
+            <th class="p-2">Sentiment</th>
+            <th class="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="r in reviews" :key="r.id" class="border-t">
+            <td class="p-2">{{ r.platform }}</td>
+            <td class="p-2">{{ r.reviewer }}</td>
+            <td class="p-2">{{ '★'.repeat(r.rating) }}</td>
+            <td class="p-2">{{ r.text }}</td>
+            <td class="p-2"><span :class="badgeClass(r.sentiment)">{{ r.sentiment }}</span></td>
+            <td class="p-2"><button class="text-primary" @click="openModal(r)">Respond</button></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <Dialog v-if="selected" @close="selected=null">
+        <div class="fixed inset-0 bg-black/30" aria-hidden="true" />
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+          <DialogPanel class="w-full max-w-md rounded bg-white p-6">
+            <DialogTitle class="text-lg font-medium">AI Suggestion</DialogTitle>
+            <p class="mt-2 text-gray-700">{{ aiResponse }}</p>
+            <div class="mt-4 flex justify-end space-x-2">
+              <button class="px-4 py-2 bg-gray-200 rounded" @click="regenerate">Regenerate</button>
+              <button class="px-4 py-2 bg-primary text-white rounded" @click="selected=null">Close</button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '../components/Sidebar.vue';
+import { useReviewsStore } from '../stores/reviews';
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue';
+import { ref } from 'vue';
+
+const reviewStore = useReviewsStore();
+const reviews = reviewStore.reviews;
+
+function badgeClass(sentiment) {
+  return {
+    'Positive': 'text-green-600',
+    'Neutral': 'text-yellow-600',
+    'Negative': 'text-red-600'
+  }[sentiment];
+}
+
+const selected = ref(null);
+const aiResponse = ref('Thank you for your feedback!');
+
+function openModal(review) {
+  selected.value = review;
+  aiResponse.value = generateResponse(review);
+}
+
+function generateResponse(review) {
+  if (review.sentiment === 'Positive') {
+    return 'Thanks for the great review!';
+  } else if (review.sentiment === 'Negative') {
+    return 'We are sorry to hear that. We will improve.';
+  }
+  return 'Thank you for your review.';
+}
+
+function regenerate() {
+  aiResponse.value = generateResponse(selected.value);
+}
+</script>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6 space-y-6">
+      <h1 class="text-2xl font-bold">Settings</h1>
+      <div class="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-4">
+        <h2 class="font-semibold">Integrations</h2>
+        <button class="px-4 py-2 bg-primary text-white rounded">Connect Google Reviews</button>
+        <button class="px-4 py-2 bg-primary text-white rounded">Connect Trustpilot</button>
+      </div>
+      <div class="bg-white dark:bg-gray-800 p-4 rounded shadow flex items-center justify-between">
+        <span class="font-semibold">Auto-reply to positive reviews</span>
+        <input type="checkbox" v-model="autoReply" class="h-5 w-5" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '../components/Sidebar.vue';
+import { ref } from 'vue';
+
+const autoReply = ref(false);
+</script>

--- a/src/pages/Signup.vue
+++ b/src/pages/Signup.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="max-w-md mx-auto py-20">
+    <h2 class="text-2xl font-bold mb-6 text-center">Sign Up</h2>
+    <form class="space-y-4">
+      <input type="email" placeholder="Email" class="w-full p-2 border rounded" />
+      <input type="password" placeholder="Password" class="w-full p-2 border rounded" />
+      <button class="w-full bg-primary text-white py-2 rounded">Sign Up</button>
+      <button class="w-full border border-gray-300 py-2 rounded flex items-center justify-center space-x-2">
+        <span>Sign up with Google</span>
+      </button>
+    </form>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,23 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import LandingPage from '../pages/LandingPage.vue';
+import Dashboard from '../pages/Dashboard.vue';
+import Reviews from '../pages/Reviews.vue';
+import Settings from '../pages/Settings.vue';
+import Billing from '../pages/Billing.vue';
+import Login from '../pages/Login.vue';
+import Signup from '../pages/Signup.vue';
+
+const routes = [
+  { path: '/', component: LandingPage },
+  { path: '/login', component: Login },
+  { path: '/signup', component: Signup },
+  { path: '/dashboard', component: Dashboard },
+  { path: '/reviews', component: Reviews },
+  { path: '/settings', component: Settings },
+  { path: '/billing', component: Billing }
+];
+
+export default createRouter({
+  history: createWebHistory(),
+  routes
+});

--- a/src/stores/reviews.js
+++ b/src/stores/reviews.js
@@ -1,0 +1,11 @@
+import { defineStore } from 'pinia';
+
+export const useReviewsStore = defineStore('reviews', {
+  state: () => ({
+    reviews: [
+      { id: 1, platform: 'Google', reviewer: 'Alice', rating: 5, text: 'Great service!', sentiment: 'Positive' },
+      { id: 2, platform: 'Trustpilot', reviewer: 'Bob', rating: 2, text: 'Not happy.', sentiment: 'Negative' },
+      { id: 3, platform: 'Google', reviewer: 'Carol', rating: 3, text: 'Okay experience', sentiment: 'Neutral' }
+    ]
+  })
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+export default {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#4F46E5'
+      }
+    }
+  },
+  darkMode: 'class',
+  plugins: []
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vue 3 + Vite + Tailwind front-end for ReputeAI
- implement landing, auth, dashboard, reviews, settings, and billing pages
- add responsive navbar, sidebar, chart component, and review interactions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@headlessui%2fvue)*
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d12b7448331ae9198c79ca927f5