### PR TITLE
Add auth forms and navbar user state

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -7,8 +7,27 @@
           <div class="hidden md:flex items-center space-x-8">
             <a href="#features" class="text-gray-700 hover:text-primary dark:text-gray-300">Features</a>
             <a href="#pricing" class="text-gray-700 hover:text-primary dark:text-gray-300">Pricing</a>
-            <router-link to="/login" class="text-gray-700 hover:text-primary dark:text-gray-300">Login</router-link>
-            <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90">Start Free Trial</router-link>
+            <template v-if="auth.isAuthed">
+              <span class="text-gray-700 dark:text-gray-300">{{ auth.me?.email }}</span>
+              <select
+                v-if="auth.me?.memberships?.length"
+                :value="auth.orgId"
+                @change="auth.setOrg(Number($event.target.value))"
+                class="border border-gray-300 rounded p-1 dark:bg-gray-800 dark:border-gray-700"
+              >
+                <option
+                  v-for="m in auth.me.memberships"
+                  :key="m.org_id"
+                  :value="m.org_id"
+                >
+                  Org {{ m.org_id }}
+                </option>
+              </select>
+            </template>
+            <template v-else>
+              <router-link to="/login" class="text-gray-700 hover:text-primary dark:text-gray-300">Login</router-link>
+              <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90">Start Free Trial</router-link>
+            </template>
           </div>
           <button @click="toggleDark" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
             <MoonIcon v-if="!isDark" class="h-5 w-5" />
@@ -23,11 +42,16 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline';
+import { useAuthStore } from '../stores/auth';
 
 const isDark = ref(false);
+const auth = useAuthStore();
 
 onMounted(() => {
   isDark.value = document.documentElement.classList.contains('dark');
+  if (auth.isAuthed && !auth.me) {
+    auth.fetchMe();
+  }
 });
 
 function toggleDark() {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -24,10 +24,18 @@ import Sidebar from '../components/Sidebar.vue';
 import Chart from '../components/Chart.vue';
 import ReviewCard from '../components/ReviewCard.vue';
 import { useReviewsStore } from '../stores/reviews';
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
+import { useAuthStore } from '../stores/auth';
 
 const reviewStore = useReviewsStore();
 const reviews = reviewStore.reviews;
+
+const auth = useAuthStore();
+onMounted(() => {
+  if (!auth.me) {
+    auth.fetchMe();
+  }
+});
 
 const totalReviews = computed(() => reviews.length);
 

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -2,11 +2,51 @@
   <div class="max-w-md mx-auto py-24 px-4">
     <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
       <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
-      <form class="space-y-4">
-        <input type="email" placeholder="Email" class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary" />
-        <input type="password" placeholder="Password" class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary" />
+      <form class="space-y-4" @submit.prevent="onSubmit">
+        <input
+          v-model="email"
+          type="email"
+          placeholder="Email"
+          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        <input
+          v-model="password"
+          type="password"
+          placeholder="Password"
+          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        <p v-if="error" class="text-red-500 text-sm">{{ error }}</p>
         <button class="w-full bg-primary text-white py-3 rounded-md hover:bg-primary/90">Login</button>
       </form>
     </div>
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useAuthStore } from '../stores/auth';
+
+const email = ref('');
+const password = ref('');
+const error = ref('');
+
+const router = useRouter();
+const auth = useAuthStore();
+
+async function onSubmit() {
+  error.value = '';
+  try {
+    await auth.login(email.value, password.value);
+    router.push('/dashboard');
+  } catch (e) {
+    if (e?.response?.status === 401) {
+      error.value = 'Invalid credentials';
+    } else if (e?.response?.status === 422) {
+      error.value = 'Validation error';
+    } else {
+      error.value = 'An error occurred';
+    }
+  }
+}
+</script>

--- a/src/pages/Signup.vue
+++ b/src/pages/Signup.vue
@@ -2,14 +2,48 @@
   <div class="max-w-md mx-auto py-24 px-4">
     <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
       <h2 class="text-2xl font-bold mb-6 text-center">Sign Up</h2>
-      <form class="space-y-4">
-        <input type="email" placeholder="Email" class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary" />
-        <input type="password" placeholder="Password" class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary" />
+      <form class="space-y-4" @submit.prevent="onSubmit">
+        <input
+          v-model="email"
+          type="email"
+          placeholder="Email"
+          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        <input
+          v-model="password"
+          type="password"
+          placeholder="Password"
+          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
+        />
         <button class="w-full bg-primary text-white py-3 rounded-md hover:bg-primary/90">Sign Up</button>
-        <button class="w-full border border-gray-300 py-3 rounded-md flex items-center justify-center space-x-2 hover:bg-gray-50 dark:hover:bg-gray-700">
+        <button
+          type="button"
+          class="w-full border border-gray-300 py-3 rounded-md flex items-center justify-center space-x-2 hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
           <span>Sign up with Google</span>
         </button>
       </form>
     </div>
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useAuthStore } from '../stores/auth';
+
+const email = ref('');
+const password = ref('');
+
+const router = useRouter();
+const auth = useAuthStore();
+
+async function onSubmit() {
+  try {
+    await auth.register(email.value, password.value);
+    router.push('/dashboard');
+  } catch (e) {
+    // no specific error handling required yet
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- implement login and signup forms using auth store
- show user email and org selector in navbar when authenticated
- fetch user info on dashboard mount if missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09866ae908331af0df4cea48491a9