### PR TITLE
feat: add reusable organization switcher

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -9,20 +9,10 @@
             <a href="#pricing" class="text-gray-700 hover:text-primary dark:text-gray-300">Pricing</a>
             <template v-if="auth.isAuthed">
               <span class="text-gray-700 dark:text-gray-300">{{ auth.me?.email }}</span>
-              <select
+              <OrgSwitcher
                 v-if="auth.me?.memberships?.length"
-                :value="auth.orgId"
-                @change="auth.setOrg(Number($event.target.value))"
-                class="border border-gray-300 rounded p-1 dark:bg-gray-800 dark:border-gray-700"
-              >
-                <option
-                  v-for="m in auth.me.memberships"
-                  :key="m.org_id"
-                  :value="m.org_id"
-                >
-                  Org {{ m.org_id }}
-                </option>
-              </select>
+                :memberships="auth.me.memberships"
+              />
             </template>
             <template v-else>
               <router-link to="/login" class="text-gray-700 hover:text-primary dark:text-gray-300">Login</router-link>
@@ -43,6 +33,7 @@
 import { ref, onMounted } from 'vue';
 import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline';
 import { useAuthStore } from '../stores/auth';
+import OrgSwitcher from './OrgSwitcher.vue';
 
 const isDark = ref(false);
 const auth = useAuthStore();

--- a/src/components/OrgSwitcher.vue
+++ b/src/components/OrgSwitcher.vue
@@ -1,0 +1,30 @@
+<template>
+  <select
+    :value="auth.orgId"
+    @change="onChange"
+    class="border border-gray-300 rounded p-1 dark:bg-gray-800 dark:border-gray-700"
+  >
+    <option
+      v-for="m in memberships"
+      :key="m.org_id"
+      :value="m.org_id"
+    >
+      Org #{{ m.org_id }}
+    </option>
+  </select>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import { useAuthStore } from '../stores/auth';
+
+type Membership = { org_id: number; role: string };
+
+defineProps<{ memberships: Membership[] }>();
+const auth = useAuthStore();
+
+function onChange(event: Event) {
+  const target = event.target as HTMLSelectElement;
+  auth.setOrg(Number(target.value));
+}
+</script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="bg-white dark:bg-gray-800 w-64 min-h-screen shadow-md hidden md:block">
+    <div v-if="auth.isAuthed && auth.me?.memberships?.length" class="p-4">
+      <OrgSwitcher :memberships="auth.me.memberships" />
+    </div>
     <nav class="mt-8 space-y-1">
       <router-link
         v-for="item in items"
@@ -15,6 +18,10 @@
 </template>
 
 <script setup>
+import OrgSwitcher from './OrgSwitcher.vue';
+import { useAuthStore } from '../stores/auth';
+
+const auth = useAuthStore();
 const items = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/reviews', label: 'Reviews' },


### PR DESCRIPTION
## Summary
- add OrgSwitcher component to change active org
- use OrgSwitcher in navbar and sidebar when memberships available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09a8a9ebc8331a09ba8c31820aff4