### PR TITLE
feat: add integrations page and callback

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -25,6 +25,7 @@ const auth = useAuthStore();
 const items = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/reviews', label: 'Reviews' },
+  { to: '/integrations', label: 'Integrations' },
   { to: '/settings', label: 'Settings' },
   { to: '/billing', label: 'Billing' }
 ];

--- a/src/pages/IntegrationCallback.vue
+++ b/src/pages/IntegrationCallback.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="p-6 text-center">Processing...</div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { api } from '../lib/api';
+
+const route = useRoute();
+const router = useRouter();
+
+onMounted(async () => {
+  const { code, state, provider } = route.query;
+  if (provider && code && state) {
+    await api.get(`/integrations/${provider}/callback`, {
+      params: { code, state }
+    });
+  }
+  router.push('/integrations');
+});
+</script>

--- a/src/pages/Integrations.vue
+++ b/src/pages/Integrations.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6 max-w-6xl mx-auto space-y-4">
+      <h1 class="text-2xl font-bold">Integrations</h1>
+      <div
+        v-for="p in providers"
+        :key="p.provider"
+        class="bg-white dark:bg-gray-800 p-4 rounded shadow flex items-center justify-between"
+      >
+        <div>
+          <h2 class="font-semibold capitalize">{{ p.provider }}</h2>
+          <p class="text-sm text-gray-600">
+            {{ p.connected ? 'Connected' : 'Not connected' }}
+          </p>
+        </div>
+        <div>
+          <button
+            v-if="p.connected"
+            class="px-4 py-2 bg-red-500 text-white rounded"
+            @click="disconnect(p.provider)"
+          >
+            Disconnect
+          </button>
+          <button
+            v-else
+            class="px-4 py-2 bg-primary text-white rounded"
+            @click="connect(p.provider)"
+          >
+            Connect
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Sidebar from '../components/Sidebar.vue';
+import { ref, onMounted } from 'vue';
+import { api } from '../lib/api';
+import { useAuthStore } from '../stores/auth';
+
+const auth = useAuthStore();
+const providers = ref([]);
+
+async function fetchIntegrations() {
+  const { data } = await api.get('/integrations/');
+  providers.value = data;
+}
+
+async function connect(provider) {
+  if (!auth.orgId) return;
+  const { data } = await api.post(
+    `/orgs/${auth.orgId}/integrations/${provider}/connect`
+  );
+  const url = data.authorization_url || data.url;
+  if (url) window.location.href = url;
+}
+
+async function disconnect(provider) {
+  if (!auth.orgId) return;
+  await api.delete(`/orgs/${auth.orgId}/integrations/${provider}`);
+  await fetchIntegrations();
+}
+
+onMounted(fetchIntegrations);
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,8 @@ import Settings from '../pages/Settings.vue';
 import Billing from '../pages/Billing.vue';
 import Login from '../pages/Login.vue';
 import Signup from '../pages/Signup.vue';
+import Integrations from '../pages/Integrations.vue';
+import IntegrationCallback from '../pages/IntegrationCallback.vue';
 
 const routes = [
   { path: '/', component: LandingPage },
@@ -13,6 +15,8 @@ const routes = [
   { path: '/signup', component: Signup },
   { path: '/dashboard', component: Dashboard },
   { path: '/reviews', component: Reviews },
+  { path: '/integrations', component: Integrations },
+  { path: '/integrations/callback', component: IntegrationCallback },
   { path: '/settings', component: Settings },
   { path: '/billing', component: Billing }
 ];


### PR DESCRIPTION
## Summary
- add integrations page to list providers and connect/disconnect via API
- handle OAuth callback and redirect back to integrations page
- expose integrations route in sidebar and router

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b09cec426483318679f332374d2f67