### PR TITLE
Add billing and usage pages with upgrade banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
     <Navbar />
+    <UpgradeBanner />
     <router-view />
   </div>
 </template>
 
 <script setup>
 import Navbar from './components/Navbar.vue';
+import UpgradeBanner from './components/UpgradeBanner.vue';
 </script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -28,6 +28,7 @@ const items = [
   { to: '/replies', label: 'Replies' },
   { to: '/integrations', label: 'Integrations' },
   { to: '/settings', label: 'Settings' },
-  { to: '/billing', label: 'Billing' }
-];
+  { to: '/billing', label: 'Billing' },
+  { to: '/usage', label: 'Usage' }
+  ];
 </script>

--- a/src/components/UpgradeBanner.vue
+++ b/src/components/UpgradeBanner.vue
@@ -1,0 +1,17 @@
+<template>
+  <div
+    v-if="usage.limitExceeded"
+    class="bg-yellow-100 border-b border-yellow-200 text-yellow-800 p-4 text-center"
+  >
+    You have reached your plan limits.
+    <router-link to="/billing" class="underline font-semibold">Upgrade your plan</router-link>
+    to continue using AI features.
+  </div>
+</template>
+
+<script setup>
+import { useUsageStore } from '../stores/usage';
+
+const usage = useUsageStore();
+</script>
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,6 +57,15 @@ export function createAxios(): AxiosInstance {
         }
       }
 
+      if (response?.status === 402 && response.data?.reason === 'limit_exceeded') {
+        const url = config?.url || '';
+        if (url.includes('/ai') || url.includes('/refresh')) {
+          const { useUsageStore } = await import('../stores/usage');
+          const usage = useUsageStore();
+          usage.triggerLimitExceeded();
+        }
+      }
+
       return Promise.reject(error);
     }
   );

--- a/src/pages/Billing.vue
+++ b/src/pages/Billing.vue
@@ -3,15 +3,59 @@
     <Sidebar />
     <div class="flex-1 p-6 max-w-6xl mx-auto">
       <h1 class="text-2xl font-bold mb-4">Billing</h1>
-      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow">
-        <p class="mb-2">Current Plan: <strong>Free</strong></p>
-        <button class="px-4 py-2 bg-primary text-white rounded">Upgrade to Pro</button>
-        <p class="mt-4 text-sm text-gray-500">Stripe checkout coming soon.</p>
+      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow space-y-4">
+        <p>Current Plan: <strong>{{ plan || '...' }}</strong></p>
+        <div class="space-x-2">
+          <button
+            v-for="p in plans"
+            :key="p"
+            @click="checkout(p)"
+            class="px-4 py-2 bg-primary text-white rounded"
+          >
+            {{ p }}
+          </button>
+        </div>
+        <button @click="openPortal" class="mt-4 underline">Open billing portal</button>
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue';
 import Sidebar from '../components/Sidebar.vue';
+import { api } from '../lib/api';
+
+const plan = ref('');
+const plans = ['FREE', 'PRO', 'BUSINESS'];
+
+async function fetchPlan() {
+  try {
+    const { data } = await api.get('/usage');
+    plan.value = data.plan || '';
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function openPortal() {
+  try {
+    const { data } = await api.get('/billing/portal');
+    if (data.url) window.open(data.url, '_blank');
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function checkout(target) {
+  try {
+    const { data } = await api.post('/billing/checkout', { plan: target });
+    if (data.url) window.location.href = data.url;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+onMounted(fetchPlan);
 </script>
+

--- a/src/pages/Usage.vue
+++ b/src/pages/Usage.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex">
+    <Sidebar />
+    <div class="flex-1 p-6 max-w-6xl mx-auto">
+      <h1 class="text-2xl font-bold mb-4">Usage</h1>
+      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow">
+        <div v-if="loading">Loading...</div>
+        <div v-else-if="error" class="text-red-600">{{ error.message || error }}</div>
+        <div v-else>
+          <p class="mb-4">Current Plan: <strong>{{ plan }}</strong></p>
+          <table class="min-w-full text-left">
+            <thead>
+              <tr>
+                <th class="p-2">Month</th>
+                <th class="p-2">Reviews fetched</th>
+                <th class="p-2">AI suggestions</th>
+                <th class="p-2">Auto replies</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(m, month) in usage" :key="month" class="border-t">
+                <td class="p-2">{{ month }}</td>
+                <td class="p-2">{{ m.reviews_fetched }}</td>
+                <td class="p-2">{{ m.ai_suggestions }}</td>
+                <td class="p-2">{{ m.auto_replies }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import Sidebar from '../components/Sidebar.vue';
+import { api } from '../lib/api';
+
+const loading = ref(false);
+const error = ref(null);
+const usage = ref({});
+const plan = ref('');
+
+async function fetchUsage() {
+  loading.value = true;
+  error.value = null;
+  try {
+    const { data } = await api.get('/usage');
+    usage.value = data.usage || {};
+    plan.value = data.plan || '';
+  } catch (e) {
+    error.value = e;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(fetchUsage);
+</script>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import Reviews from '../pages/Reviews.vue';
 import Replies from '../pages/Replies.vue';
 import Settings from '../pages/Settings.vue';
 import Billing from '../pages/Billing.vue';
+import Usage from '../pages/Usage.vue';
 import Login from '../pages/Login.vue';
 import Signup from '../pages/Signup.vue';
 import Integrations from '../pages/Integrations.vue';
@@ -20,7 +21,8 @@ const routes = [
   { path: '/integrations', component: Integrations },
   { path: '/integrations/callback', component: IntegrationCallback },
   { path: '/settings', component: Settings },
-  { path: '/billing', component: Billing }
+  { path: '/billing', component: Billing },
+  { path: '/usage', component: Usage }
 ];
 
 export default createRouter({

--- a/src/stores/usage.ts
+++ b/src/stores/usage.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia';
+
+export const useUsageStore = defineStore('usage', {
+  state: () => ({
+    limitExceeded: false
+  }),
+  actions: {
+    triggerLimitExceeded() {
+      this.limitExceeded = true;
+    },
+    clearLimitExceeded() {
+      this.limitExceeded = false;
+    }
+  }
+});
+


### PR DESCRIPTION
## Summary
- implement functional Billing page with portal and plan checkout
- add Usage page to show monthly metrics
- show upgrade banner when hitting plan limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3e541848331b091d9bee7bb5c25