### PR TITLE
feat: add dark mode toggle and UI polish

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -1,0 +1,49 @@
+<template>
+  <button
+    :class="['inline-flex items-center justify-center rounded-md px-4 py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed', variantClasses]"
+    v-bind="$attrs"
+  >
+    <svg
+      v-if="loading"
+      class="animate-spin h-5 w-5 mr-2 text-current"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        class="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        stroke-width="4"
+      ></circle>
+      <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+    <span><slot /></span>
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  variant: { type: String, default: 'primary' },
+  loading: { type: Boolean, default: false }
+});
+
+const variantClasses = computed(() => {
+  switch (props.variant) {
+    case 'secondary':
+      return 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700';
+    case 'danger':
+      return 'bg-red-600 text-white hover:bg-red-700';
+    default:
+      return 'bg-primary text-white hover:bg-primary/90';
+  }
+});
+</script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -14,15 +14,17 @@
                 :memberships="auth.me.memberships"
               />
             </template>
-            <template v-else>
-              <router-link to="/login" class="text-gray-700 hover:text-primary dark:text-gray-300">Login</router-link>
-              <router-link to="/signup" class="px-4 py-2 bg-primary text-white rounded-md shadow hover:bg-primary/90">Start Free Trial</router-link>
-            </template>
-          </div>
-          <button @click="toggleDark" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
-            <MoonIcon v-if="!isDark" class="h-5 w-5" />
-            <SunIcon v-else class="h-5 w-5" />
-          </button>
+              <template v-else>
+                <router-link to="/login" class="text-gray-700 hover:text-primary dark:text-gray-300">Login</router-link>
+                <router-link to="/signup">
+                  <BaseButton>Start Free Trial</BaseButton>
+                </router-link>
+              </template>
+            </div>
+            <button @click="toggleDark" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
+              <MoonIcon v-if="!isDark" class="h-5 w-5" />
+              <SunIcon v-else class="h-5 w-5" />
+            </button>
         </div>
       </div>
     </div>
@@ -31,22 +33,25 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline';
-import { useAuthStore } from '../stores/auth';
-import OrgSwitcher from './OrgSwitcher.vue';
+  import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline';
+  import { useAuthStore } from '../stores/auth';
+  import OrgSwitcher from './OrgSwitcher.vue';
+  import BaseButton from './BaseButton.vue';
 
-const isDark = ref(false);
-const auth = useAuthStore();
+  const isDark = ref(false);
+  const auth = useAuthStore();
 
-onMounted(() => {
-  isDark.value = document.documentElement.classList.contains('dark');
-  if (auth.isAuthed && !auth.me) {
-    auth.fetchMe();
+  onMounted(() => {
+    const stored = localStorage.getItem('theme');
+    isDark.value = stored ? stored === 'dark' : document.documentElement.classList.contains('dark');
+    if (auth.isAuthed && !auth.me) {
+      auth.fetchMe();
+    }
+  });
+
+  function toggleDark() {
+    isDark.value = !isDark.value;
+    document.documentElement.classList.toggle('dark', isDark.value);
+    localStorage.setItem('theme', isDark.value ? 'dark' : 'light');
   }
-});
-
-function toggleDark() {
-  isDark.value = !isDark.value;
-  document.documentElement.classList.toggle('dark', isDark.value);
-}
 </script>

--- a/src/components/SuggestReplyModal.vue
+++ b/src/components/SuggestReplyModal.vue
@@ -21,61 +21,52 @@
           <input v-model="language" class="border p-1 rounded w-full" />
         </label>
 
-        <button
-          @click="fetchSuggestions"
-          class="bg-primary text-white px-3 py-1 rounded"
-          :disabled="loading"
-        >
-          {{ loading ? 'Loading...' : 'Suggest' }}
-        </button>
+          <BaseButton @click="fetchSuggestions" :loading="loading">Suggest</BaseButton>
         <div v-if="error" class="text-red-600">{{ error }}</div>
       </div>
 
-      <div v-for="s in suggestions" :key="s" class="border p-2 rounded mb-2">
-        <p>{{ s }}</p>
-        <div class="flex gap-2 mt-2">
-          <button @click="copy(s)" class="px-2 py-1 border rounded">Copy</button>
-          <button
-            @click="useSuggestion(s)"
-            class="px-2 py-1 bg-primary text-white rounded"
-          >
-            Use this
-          </button>
+        <div v-for="s in suggestions" :key="s" class="border p-2 rounded mb-2">
+          <p>{{ s }}</p>
+          <div class="flex gap-2 mt-2">
+            <BaseButton variant="secondary" class="px-2 py-1" @click="copy(s)">Copy</BaseButton>
+            <BaseButton class="px-2 py-1" @click="useSuggestion(s)">Use this</BaseButton>
+          </div>
         </div>
-      </div>
 
       <div class="mt-4 space-y-2">
-        <textarea
-          v-model="replyText"
-          rows="4"
-          class="border p-2 rounded w-full"
-          placeholder="Type your reply here"
-        ></textarea>
-        <div class="flex gap-2">
-          <button
-            @click="saveDraft"
-            class="px-3 py-1 bg-gray-200 rounded"
-            :disabled="saving"
-          >
-            {{ saving ? 'Saving...' : 'Save as draft' }}
-          </button>
-          <button
-            @click="sendReply"
-            class="px-3 py-1 bg-primary text-white rounded"
-            :disabled="sending"
-          >
-            {{ sending ? 'Sending...' : 'Send to platform' }}
-          </button>
+          <textarea
+            v-model="replyText"
+            rows="4"
+            class="border p-2 rounded w-full dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+            placeholder="Type your reply here"
+          ></textarea>
+          <div class="flex gap-2">
+            <BaseButton
+              variant="secondary"
+              class="px-3 py-1"
+              :loading="saving"
+              @click="saveDraft"
+            >
+              Save as draft
+            </BaseButton>
+            <BaseButton
+              class="px-3 py-1"
+              :loading="sending"
+              @click="sendReply"
+            >
+              Send to platform
+            </BaseButton>
+          </div>
         </div>
-      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import { api } from '../lib/api';
-import { useAuthStore } from '../stores/auth';
+  import { ref } from 'vue';
+  import { api } from '../lib/api';
+  import { useAuthStore } from '../stores/auth';
+  import BaseButton from './BaseButton.vue';
 
 const props = defineProps({
   review: { type: Object, required: true }

--- a/src/components/TableSkeleton.vue
+++ b/src/components/TableSkeleton.vue
@@ -1,0 +1,18 @@
+<template>
+  <table class="min-w-full">
+    <tbody>
+      <tr v-for="r in rows" :key="r" class="animate-pulse">
+        <td v-for="c in cols" :key="c" class="p-2">
+          <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded"></div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup>
+const props = defineProps({
+  rows: { type: Number, default: 5 },
+  cols: { type: Number, default: 5 }
+});
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,11 @@ import App from './App.vue';
 import router from './router';
 import './index.css';
 
+const storedTheme = localStorage.getItem('theme');
+if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  document.documentElement.classList.add('dark');
+}
+
 const app = createApp(App);
 app.use(createPinia());
 app.use(router);

--- a/src/pages/Billing.vue
+++ b/src/pages/Billing.vue
@@ -3,59 +3,75 @@
     <Sidebar />
     <div class="flex-1 p-6 max-w-6xl mx-auto">
       <h1 class="text-2xl font-bold mb-4">Billing</h1>
-      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow space-y-4">
-        <p>Current Plan: <strong>{{ plan || '...' }}</strong></p>
-        <div class="space-x-2">
-          <button
-            v-for="p in plans"
-            :key="p"
-            @click="checkout(p)"
-            class="px-4 py-2 bg-primary text-white rounded"
+        <div class="bg-white dark:bg-gray-800 p-6 rounded shadow space-y-4">
+          <p>Current Plan: <strong>{{ plan || '...' }}</strong></p>
+          <div class="space-x-2">
+            <BaseButton
+              v-for="p in plans"
+              :key="p"
+              @click="checkout(p)"
+              :loading="loadingPlan === p"
+            >
+              {{ p }}
+            </BaseButton>
+          </div>
+          <BaseButton
+            class="mt-4"
+            variant="secondary"
+            :loading="loadingPortal"
+            @click="openPortal"
           >
-            {{ p }}
-          </button>
+            Open billing portal
+          </BaseButton>
         </div>
-        <button @click="openPortal" class="mt-4 underline">Open billing portal</button>
       </div>
     </div>
-  </div>
-</template>
+  </template>
 
-<script setup>
-import { ref, onMounted } from 'vue';
-import Sidebar from '../components/Sidebar.vue';
-import { api } from '../lib/api';
+  <script setup>
+  import { ref, onMounted } from 'vue';
+  import Sidebar from '../components/Sidebar.vue';
+  import { api } from '../lib/api';
+  import BaseButton from '../components/BaseButton.vue';
 
-const plan = ref('');
-const plans = ['FREE', 'PRO', 'BUSINESS'];
+  const plan = ref('');
+  const plans = ['FREE', 'PRO', 'BUSINESS'];
+  const loadingPlan = ref('');
+  const loadingPortal = ref(false);
 
-async function fetchPlan() {
-  try {
-    const { data } = await api.get('/usage');
-    plan.value = data.plan || '';
-  } catch (e) {
-    console.error(e);
+  async function fetchPlan() {
+    try {
+      const { data } = await api.get('/usage');
+      plan.value = data.plan || '';
+    } catch (e) {
+      console.error(e);
+    }
   }
-}
 
-async function openPortal() {
-  try {
-    const { data } = await api.get('/billing/portal');
-    if (data.url) window.open(data.url, '_blank');
-  } catch (e) {
-    console.error(e);
+  async function openPortal() {
+    loadingPortal.value = true;
+    try {
+      const { data } = await api.get('/billing/portal');
+      if (data.url) window.open(data.url, '_blank');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      loadingPortal.value = false;
+    }
   }
-}
 
-async function checkout(target) {
-  try {
-    const { data } = await api.post('/billing/checkout', { plan: target });
-    if (data.url) window.location.href = data.url;
-  } catch (e) {
-    console.error(e);
+  async function checkout(target) {
+    loadingPlan.value = target;
+    try {
+      const { data } = await api.post('/billing/checkout', { plan: target });
+      if (data.url) window.location.href = data.url;
+    } catch (e) {
+      console.error(e);
+    } finally {
+      loadingPlan.value = '';
+    }
   }
-}
 
-onMounted(fetchPlan);
-</script>
+  onMounted(fetchPlan);
+  </script>
 

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -1,64 +1,76 @@
 <template>
   <div>
     <!-- Hero -->
-    <section class="relative overflow-hidden">
-      <div class="max-w-5xl mx-auto px-4 py-24 text-center">
-        <h1 class="text-4xl md:text-5xl font-bold mb-6">Manage Your Online Reputation with AI</h1>
-        <p class="text-lg text-gray-600 mb-8">Monitor reviews, analyze sentiment, and respond in seconds. Let AI handle your online presence while you focus on business growth.</p>
-        <div class="flex justify-center space-x-4">
-          <router-link to="/signup" class="px-6 py-3 bg-primary text-white rounded-md shadow hover:bg-primary/90">Start Free Trial</router-link>
-          <router-link to="/demo" class="px-6 py-3 border border-primary text-primary rounded-md hover:bg-primary/10">View Demo</router-link>
+      <section class="relative overflow-hidden bg-white dark:bg-gray-900">
+        <div class="max-w-5xl mx-auto px-4 py-24 text-center">
+          <h1 class="text-4xl md:text-5xl font-bold mb-6">Manage Your Online Reputation with AI</h1>
+          <p class="text-lg text-gray-600 dark:text-gray-300 mb-8">Monitor reviews, analyze sentiment, and respond in seconds. Let AI handle your online presence while you focus on business growth.</p>
+          <div class="flex justify-center space-x-4">
+            <router-link to="/signup">
+              <BaseButton class="px-6 py-3">Start Free Trial</BaseButton>
+            </router-link>
+            <router-link to="/demo">
+              <BaseButton class="px-6 py-3" variant="secondary">View Demo</BaseButton>
+            </router-link>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <!-- Features -->
-    <section id="features" class="py-24 bg-white">
-      <div class="max-w-6xl mx-auto px-4">
-        <h2 class="text-3xl font-bold text-center mb-12">Everything you need to manage reviews</h2>
-        <div class="grid md:grid-cols-3 gap-8">
-          <div class="p-6 bg-gray-50 rounded-lg shadow-sm text-center">
-            <h3 class="font-semibold mb-2">Track Google & Trustpilot</h3>
-            <p class="text-gray-600">Stay updated with new feedback across platforms.</p>
-          </div>
-          <div class="p-6 bg-gray-50 rounded-lg shadow-sm text-center">
-            <h3 class="font-semibold mb-2">AI Sentiment Analysis</h3>
-            <p class="text-gray-600">Understand customer feelings instantly.</p>
-          </div>
-          <div class="p-6 bg-gray-50 rounded-lg shadow-sm text-center">
-            <h3 class="font-semibold mb-2">Suggested Responses</h3>
-            <p class="text-gray-600">Reply confidently with AI-generated messages.</p>
+      <section id="features" class="py-24 bg-white dark:bg-gray-900">
+        <div class="max-w-6xl mx-auto px-4">
+          <h2 class="text-3xl font-bold text-center mb-12">Everything you need to manage reviews</h2>
+          <div class="grid md:grid-cols-3 gap-8">
+            <div class="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow-sm text-center">
+              <h3 class="font-semibold mb-2">Track Google & Trustpilot</h3>
+              <p class="text-gray-600 dark:text-gray-400">Stay updated with new feedback across platforms.</p>
+            </div>
+            <div class="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow-sm text-center">
+              <h3 class="font-semibold mb-2">AI Sentiment Analysis</h3>
+              <p class="text-gray-600 dark:text-gray-400">Understand customer feelings instantly.</p>
+            </div>
+            <div class="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow-sm text-center">
+              <h3 class="font-semibold mb-2">Suggested Responses</h3>
+              <p class="text-gray-600 dark:text-gray-400">Reply confidently with AI-generated messages.</p>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <!-- Pricing -->
-    <section id="pricing" class="py-24 bg-gray-50">
-      <div class="max-w-6xl mx-auto px-4 text-center">
-        <h2 class="text-3xl font-bold mb-12">Simple, transparent pricing</h2>
-        <div class="grid md:grid-cols-2 gap-8">
-          <div class="bg-white rounded-lg p-8 shadow">
-            <h3 class="text-xl font-semibold mb-2">Free Plan</h3>
-            <p class="text-gray-600 mb-6">Up to 10 reviews/month</p>
-            <router-link to="/signup" class="inline-block px-6 py-3 bg-primary text-white rounded-md shadow hover:bg-primary/90">Get Started</router-link>
-          </div>
-          <div class="bg-white rounded-lg p-8 shadow ring-2 ring-primary">
-            <h3 class="text-xl font-semibold mb-2">Pro Plan</h3>
-            <p class="text-gray-600 mb-6">Unlimited reviews + AI responses<br />€29/month</p>
-            <router-link to="/signup" class="inline-block px-6 py-3 bg-primary text-white rounded-md shadow hover:bg-primary/90">Upgrade</router-link>
+      <section id="pricing" class="py-24 bg-gray-50 dark:bg-gray-900">
+        <div class="max-w-6xl mx-auto px-4 text-center">
+          <h2 class="text-3xl font-bold mb-12">Simple, transparent pricing</h2>
+          <div class="grid md:grid-cols-2 gap-8">
+            <div class="bg-white dark:bg-gray-800 rounded-lg p-8 shadow">
+              <h3 class="text-xl font-semibold mb-2">Free Plan</h3>
+              <p class="text-gray-600 dark:text-gray-400 mb-6">Up to 10 reviews/month</p>
+              <router-link to="/signup">
+                <BaseButton class="px-6 py-3">Get Started</BaseButton>
+              </router-link>
+            </div>
+            <div class="bg-white dark:bg-gray-800 rounded-lg p-8 shadow ring-2 ring-primary">
+              <h3 class="text-xl font-semibold mb-2">Pro Plan</h3>
+              <p class="text-gray-600 dark:text-gray-400 mb-6">Unlimited reviews + AI responses<br />€29/month</p>
+              <router-link to="/signup">
+                <BaseButton class="px-6 py-3">Upgrade</BaseButton>
+              </router-link>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
 
     <!-- Footer -->
-    <footer class="py-8 text-center text-gray-500">
-      <div class="space-x-4">
-        <a href="#">About</a>
-        <a href="#pricing">Pricing</a>
-        <a href="#">Contact</a>
-      </div>
-    </footer>
-  </div>
-</template>
+      <footer class="py-8 text-center text-gray-500 dark:text-gray-400">
+        <div class="space-x-4">
+          <a href="#">About</a>
+          <a href="#pricing">Pricing</a>
+          <a href="#">Contact</a>
+        </div>
+      </footer>
+    </div>
+  </template>
+
+  <script setup>
+  import BaseButton from '../components/BaseButton.vue';
+  </script>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,52 +1,57 @@
 <template>
   <div class="max-w-md mx-auto py-24 px-4">
-    <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
-      <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
-      <form class="space-y-4" @submit.prevent="onSubmit">
-        <input
-          v-model="email"
-          type="email"
-          placeholder="Email"
-          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <input
-          v-model="password"
-          type="password"
-          placeholder="Password"
-          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <p v-if="error" class="text-red-500 text-sm">{{ error }}</p>
-        <button class="w-full bg-primary text-white py-3 rounded-md hover:bg-primary/90">Login</button>
-      </form>
+      <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
+        <h2 class="text-2xl font-bold mb-6 text-center">Login</h2>
+        <form class="space-y-4" @submit.prevent="onSubmit">
+          <input
+            v-model="email"
+            type="email"
+            placeholder="Email"
+            class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+          />
+          <input
+            v-model="password"
+            type="password"
+            placeholder="Password"
+            class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+          />
+          <p v-if="error" class="text-red-500 text-sm">{{ error }}</p>
+          <BaseButton class="w-full" :loading="loading" type="submit">Login</BaseButton>
+        </form>
+      </div>
     </div>
-  </div>
-</template>
+  </template>
 
-<script setup>
-import { ref } from 'vue';
-import { useRouter } from 'vue-router';
-import { useAuthStore } from '../stores/auth';
+  <script setup>
+  import { ref } from 'vue';
+  import { useRouter } from 'vue-router';
+  import { useAuthStore } from '../stores/auth';
+  import BaseButton from '../components/BaseButton.vue';
 
-const email = ref('');
-const password = ref('');
-const error = ref('');
+  const email = ref('');
+  const password = ref('');
+  const error = ref('');
+  const loading = ref(false);
 
-const router = useRouter();
-const auth = useAuthStore();
+  const router = useRouter();
+  const auth = useAuthStore();
 
-async function onSubmit() {
-  error.value = '';
-  try {
-    await auth.login(email.value, password.value);
-    router.push('/dashboard');
-  } catch (e) {
-    if (e?.response?.status === 401) {
-      error.value = 'Invalid credentials';
-    } else if (e?.response?.status === 422) {
-      error.value = 'Validation error';
-    } else {
-      error.value = 'An error occurred';
+  async function onSubmit() {
+    error.value = '';
+    loading.value = true;
+    try {
+      await auth.login(email.value, password.value);
+      router.push('/dashboard');
+    } catch (e) {
+      if (e?.response?.status === 401) {
+        error.value = 'Invalid credentials';
+      } else if (e?.response?.status === 422) {
+        error.value = 'Validation error';
+      } else {
+        error.value = 'An error occurred';
+      }
+    } finally {
+      loading.value = false;
     }
   }
-}
-</script>
+  </script>

--- a/src/pages/Replies.vue
+++ b/src/pages/Replies.vue
@@ -4,23 +4,25 @@
     <div class="flex-1 p-6 max-w-6xl mx-auto">
       <h1 class="text-2xl font-bold mb-4">Replies</h1>
 
-      <div class="mb-4 flex items-center gap-2">
-        <input
-          v-model="reviewId"
-          type="text"
-          placeholder="Filter by review ID"
-          class="border p-1 rounded"
-        />
-        <button @click="fetchReplies" class="bg-primary text-white px-3 py-1 rounded">
-          Refresh
-        </button>
-      </div>
+        <div class="mb-4 flex items-center gap-2">
+          <input
+            v-model="reviewId"
+            type="text"
+            placeholder="Filter by review ID"
+            class="border p-1 rounded"
+          />
+          <BaseButton @click="fetchReplies" :loading="loading">
+            Refresh
+          </BaseButton>
+        </div>
 
-      <div v-if="loading">Loading...</div>
-      <div v-else-if="error" class="text-red-600">{{ error }}</div>
-      <div v-else>
-        <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
-          <thead>
+        <div v-if="loading" class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+          <TableSkeleton :cols="5" :rows="5" />
+        </div>
+        <div v-else-if="error" class="text-red-600">{{ error }}</div>
+        <div v-else>
+          <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+            <thead>
             <tr class="text-left">
               <th class="p-2">Review ID</th>
               <th class="p-2">Text</th>
@@ -49,6 +51,8 @@ import Sidebar from '../components/Sidebar.vue';
 import { ref, onMounted } from 'vue';
 import { api } from '../lib/api';
 import { useAuthStore } from '../stores/auth';
+import BaseButton from '../components/BaseButton.vue';
+import TableSkeleton from '../components/TableSkeleton.vue';
 
 const auth = useAuthStore();
 const reviewId = ref('');

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -3,11 +3,11 @@
     <Sidebar />
     <div class="flex-1 p-6 max-w-6xl mx-auto space-y-6">
       <h1 class="text-2xl font-bold">Settings</h1>
-      <div class="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-4">
-        <h2 class="font-semibold">Integrations</h2>
-        <button class="px-4 py-2 bg-primary text-white rounded">Connect Google Reviews</button>
-        <button class="px-4 py-2 bg-primary text-white rounded">Connect Trustpilot</button>
-      </div>
+        <div class="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-4">
+          <h2 class="font-semibold">Integrations</h2>
+          <BaseButton>Connect Google Reviews</BaseButton>
+          <BaseButton>Connect Trustpilot</BaseButton>
+        </div>
       <div class="bg-white dark:bg-gray-800 p-4 rounded shadow flex items-center justify-between">
         <span class="font-semibold">Auto-reply to positive reviews</span>
         <input type="checkbox" v-model="autoReply" class="h-5 w-5" />
@@ -19,6 +19,7 @@
 <script setup>
 import Sidebar from '../components/Sidebar.vue';
 import { ref } from 'vue';
+import BaseButton from '../components/BaseButton.vue';
 
 const autoReply = ref(false);
 </script>

--- a/src/pages/Signup.vue
+++ b/src/pages/Signup.vue
@@ -1,49 +1,53 @@
 <template>
   <div class="max-w-md mx-auto py-24 px-4">
-    <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
-      <h2 class="text-2xl font-bold mb-6 text-center">Sign Up</h2>
-      <form class="space-y-4" @submit.prevent="onSubmit">
-        <input
-          v-model="email"
-          type="email"
-          placeholder="Email"
-          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <input
-          v-model="password"
-          type="password"
-          placeholder="Password"
-          class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary"
-        />
-        <button class="w-full bg-primary text-white py-3 rounded-md hover:bg-primary/90">Sign Up</button>
-        <button
-          type="button"
-          class="w-full border border-gray-300 py-3 rounded-md flex items-center justify-center space-x-2 hover:bg-gray-50 dark:hover:bg-gray-700"
-        >
-          <span>Sign up with Google</span>
-        </button>
-      </form>
+      <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
+        <h2 class="text-2xl font-bold mb-6 text-center">Sign Up</h2>
+        <form class="space-y-4" @submit.prevent="onSubmit">
+          <input
+            v-model="email"
+            type="email"
+            placeholder="Email"
+            class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+          />
+          <input
+            v-model="password"
+            type="password"
+            placeholder="Password"
+            class="w-full p-3 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-primary dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+          />
+          <BaseButton class="w-full" :loading="loading" type="submit">Sign Up</BaseButton>
+          <BaseButton
+            type="button"
+            class="w-full"
+            variant="secondary"
+          >
+            Sign up with Google
+          </BaseButton>
+        </form>
+      </div>
     </div>
-  </div>
-</template>
+  </template>
 
-<script setup>
-import { ref } from 'vue';
-import { useRouter } from 'vue-router';
-import { useAuthStore } from '../stores/auth';
+  <script setup>
+  import { ref } from 'vue';
+  import { useRouter } from 'vue-router';
+  import { useAuthStore } from '../stores/auth';
+  import BaseButton from '../components/BaseButton.vue';
 
-const email = ref('');
-const password = ref('');
+  const email = ref('');
+  const password = ref('');
+  const loading = ref(false);
 
-const router = useRouter();
-const auth = useAuthStore();
+  const router = useRouter();
+  const auth = useAuthStore();
 
-async function onSubmit() {
-  try {
-    await auth.register(email.value, password.value);
-    router.push('/dashboard');
-  } catch (e) {
-    // no specific error handling required yet
+  async function onSubmit() {
+    loading.value = true;
+    try {
+      await auth.register(email.value, password.value);
+      router.push('/dashboard');
+    } finally {
+      loading.value = false;
+    }
   }
-}
-</script>
+  </script>

--- a/src/pages/Usage.vue
+++ b/src/pages/Usage.vue
@@ -3,13 +3,13 @@
     <Sidebar />
     <div class="flex-1 p-6 max-w-6xl mx-auto">
       <h1 class="text-2xl font-bold mb-4">Usage</h1>
-      <div class="bg-white dark:bg-gray-800 p-6 rounded shadow">
-        <div v-if="loading">Loading...</div>
-        <div v-else-if="error" class="text-red-600">{{ error.message || error }}</div>
-        <div v-else>
-          <p class="mb-4">Current Plan: <strong>{{ plan }}</strong></p>
-          <table class="min-w-full text-left">
-            <thead>
+        <div class="bg-white dark:bg-gray-800 p-6 rounded shadow">
+          <TableSkeleton v-if="loading" :cols="4" :rows="3" />
+          <div v-else-if="error" class="text-red-600">{{ error.message || error }}</div>
+          <div v-else>
+            <p class="mb-4">Current Plan: <strong>{{ plan }}</strong></p>
+            <table class="min-w-full text-left">
+              <thead>
               <tr>
                 <th class="p-2">Month</th>
                 <th class="p-2">Reviews fetched</th>
@@ -36,6 +36,7 @@
 import { ref, onMounted } from 'vue';
 import Sidebar from '../components/Sidebar.vue';
 import { api } from '../lib/api';
+import TableSkeleton from '../components/TableSkeleton.vue';
 
 const loading = ref(false);
 const error = ref(null);


### PR DESCRIPTION
## Summary
- persist dark mode preference in localStorage and apply on load
- add BaseButton component with variants and loading spinner
- introduce table skeleton loaders and use them in pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a55a91ec8331a5f40a55015e54b3