### PR TITLE
Add developer tools card to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env.local

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -13,6 +13,24 @@
           <Chart :type="'pie'" :data="chartData" />
         </div>
       </div>
+      <div
+        v-if="isDev"
+        class="p-4 bg-white dark:bg-gray-800 rounded shadow mb-6"
+      >
+        <h2 class="text-lg font-semibold mb-2">Developer</h2>
+        <div class="flex gap-2 mb-2">
+          <BaseButton variant="secondary" @click="fetchDev('/me')">
+            Me
+          </BaseButton>
+          <BaseButton variant="secondary" @click="fetchDev('/usage/')">
+            Usage
+          </BaseButton>
+          <BaseButton variant="secondary" @click="fetchDev('/health')">
+            Health
+          </BaseButton>
+        </div>
+        <pre v-if="devOutput" class="text-xs whitespace-pre-wrap">{{ devOutput }}</pre>
+      </div>
       <h2 class="text-lg font-semibold mb-2">Recent Reviews</h2>
       <ReviewCard v-for="r in reviews.slice(0,3)" :key="r.id" :review="r" />
     </div>
@@ -24,8 +42,9 @@ import Sidebar from '../components/Sidebar.vue';
 import Chart from '../components/Chart.vue';
 import ReviewCard from '../components/ReviewCard.vue';
 import { useReviewsStore } from '../stores/reviews';
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useAuthStore } from '../stores/auth';
+import BaseButton from '../components/BaseButton.vue';
 
 const reviewStore = useReviewsStore();
 const reviews = reviewStore.reviews;
@@ -52,4 +71,17 @@ const chartData = {
     }
   ]
 };
+
+const isDev = import.meta.env.DEV;
+const devOutput = ref('');
+
+async function fetchDev(path) {
+  try {
+    const res = await fetch(path, { credentials: 'include' });
+    const data = await res.json();
+    devOutput.value = JSON.stringify(data, null, 2);
+  } catch (err) {
+    devOutput.value = String(err);
+  }
+}
 </script>


### PR DESCRIPTION
## Summary
- add developer card with buttons to fetch `/me`, `/usage/`, `/health`
- show fetched JSON for quick header/token checks
- ignore build artifacts and local env files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a762a098833196782647516faf70